### PR TITLE
LLM adapter v0.1 - Real Kimi K2 + PromptContract + auto-consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ demo-s1:
 demo-s1-llm:
 	. .venv/bin/activate && $(PY) orchestrator/skeleton_llm.py --plan plans/plan-hello.json --state state/x-hello.json --llm kimi
 
+demo-llm:
+	. .venv/bin/activate && $(PY) orchestrator/skeleton_llm.py --plan plans/plan-hello.json --state state/x-hello.json --llm kimi --verifier local
+
 demo-s1-mock:
 	. .venv/bin/activate && $(PY) orchestrator/skeleton_llm.py --plan plans/plan-hello.json --state state/x-hello.json --llm mock
 

--- a/configs/llm.yaml
+++ b/configs/llm.yaml
@@ -1,47 +1,11 @@
-# LLM Configuration v0.1
-defaults:
-  model: "moonshotai/kimi-k2:free"
-  n_consistency: 3
-  temperature: 0.0
-  top_p: 1.0
-  max_tokens: 800
-  cache_enabled: true
-  logs_enabled: true
-
-# Budgets per operator
-budgets:
-  meet:
-    tokens: 400
-    latency_ms: 2000
-  generalize:
-    tokens: 600
-    latency_ms: 3000
-  refute:
-    tokens: 300
-    latency_ms: 1500
-  specialize:
-    tokens: 500
-    latency_ms: 2500
-  contrast:
-    tokens: 400
-    latency_ms: 2000
-  normalize:
-    tokens: 300
-    latency_ms: 1500
-  verify:
-    tokens: 200
-    latency_ms: 1000
-
-# Retry configuration
-retry:
-  max_attempts: 5
-  base_delay: 0.5
-  max_delay: 4.0
-  exponential_base: 2.0
-
-# Security
-security:
-  log_redaction: true
-  hmac_secret_env: "LLM_LOG_SECRET"
-  cache_ttl_hours: 24
-  max_prompt_length: 10000
+# LLM Configuration Defaults
+model: "moonshotai/kimi-k2:free"
+n_consistency: 3
+temperature: 0.0
+top_p: 1.0
+max_tokens: 800
+retries:
+  stop_after_attempt: 5
+  wait_exponential_multiplier: 0.5
+  wait_exponential_min: 0.5
+  wait_exponential_max: 4.0

--- a/env.example
+++ b/env.example
@@ -1,15 +1,18 @@
 # OpenRouter Configuration
-OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_API_KEY=your_api_key_here
 OPENROUTER_MODEL=moonshotai/kimi-k2:free
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
-HTTP_REFERER=https://github.com/romainpeter/proofengine
-X_TITLE=ProofEngine Demo
 
-# LLM Client Configuration
-LLM_CACHE_DIR=proofengine/out/llm_cache
-LLM_LOGS_DIR=proofengine/out/llm_logs
+# LLM Configuration
 LLM_N_CONSISTENCY=3
 LLM_TEMPERATURE=0.0
 LLM_TOP_P=1.0
 LLM_MAX_TOKENS=800
-LLM_LOG_SECRET=change-me-in-production
+
+# Cache and Logs
+LLM_CACHE_DIR=proofengine/out/llm_cache
+LLM_LOGS_DIR=proofengine/out/llm_logs
+LLM_LOG_SECRET=your_log_secret_here
+
+# Offline Mode
+PROOFENGINE_OFFLINE=0

--- a/proofengine/adapters/openrouter.py
+++ b/proofengine/adapters/openrouter.py
@@ -6,7 +6,7 @@ import os
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
 
-from ..core.llm_client_v2 import LLMClient, LLMConfig
+from ..core.llm_client import LLMClient, LLMConfig
 
 
 @dataclass

--- a/schemas/prompt_contract.schema.json
+++ b/schemas/prompt_contract.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://spec.proof.engine/v0.1/prompt_contract.schema.json",
+  "title": "Prompt Contract v0.1",
+  "description": "Schema for structured LLM prompt contracts, ensuring consistent input/output.",
+  "type": "object",
+  "required": ["version", "role", "task", "inputs", "constraints", "output_schema_uri", "budgets"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^0\\.1\\.0$",
+      "description": "Version of the PromptContract schema."
+    },
+    "role": {
+      "type": "string",
+      "enum": ["Meet", "Generalize", "Refute"],
+      "description": "The role of the LLM in this interaction (e.g., planning, action generation, failure analysis)."
+    },
+    "task": {
+      "type": "string",
+      "description": "A clear, concise description of the task the LLM needs to perform."
+    },
+    "inputs": {
+      "type": "array",
+      "description": "List of structured inputs provided to the LLM.",
+      "items": {
+        "type": "object",
+        "required": ["name", "type", "value"],
+        "properties": {
+          "name": {"type": "string"},
+          "type": {"type": "string"},
+          "value": {"type": "string", "description": "JSON string representation of the input value."}
+        }
+      }
+    },
+    "constraints": {
+      "type": "array",
+      "description": "List of constraints the LLM must adhere to (e.g., 'JSON output only', 'Consider all obligations').",
+      "items": {"type": "string"}
+    },
+    "output_schema_uri": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI pointing to the JSON schema that the LLM's output must conform to."
+    },
+    "budgets": {
+      "type": "object",
+      "description": "Resource budgets for the LLM call.",
+      "required": ["tokens", "latency_ms"],
+      "properties": {
+        "tokens": {"type": "integer", "minimum": 1},
+        "latency_ms": {"type": "integer", "minimum": 1}
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_orchestrator_llm.py
+++ b/tests/test_orchestrator_llm.py
@@ -5,7 +5,6 @@ Tests for Orchestrator LLM adapter
 import tempfile
 from unittest.mock import patch, MagicMock
 
-
 from orchestrator.adapter_llm import OrchestratorLLMAdapter, PromptContract
 
 


### PR DESCRIPTION
- proofengine/core/llm_client.py: retry, cache, auto-consistency n=3, HMAC logs
- proofengine/adapters/openrouter.py: OpenRouter API adapter with headers
- orchestrator/adapter_llm.py: PromptContract for Meet/Generalize/Refute operators
- schemas/prompt_contract.schema.json: JSON schema for structured prompts
- configs/llm.yaml: LLM configuration defaults
- tests/test_llm_client.py: comprehensive tests with mocks (no real API calls)
- tests/test_orchestrator_llm.py: adapter tests with fallback validation
- env.example: environment variables template
- Makefile: demo-llm target

Features:
- Auto-consistency: n=3 calls, best response selection
- Caching: deterministic cache keys, offline replay
- Logging: HMAC-signed logs, redacted prompts
- Validation: response schema compliance, fallback on invalid JSON
- Offline mode: mock responses when no API key

Acceptance:
- make demo-llm ≥ 90% accept_rate vs stub (±10%)
- Logs jsonl signed, cache used (2nd call offline OK)
- CI green with mocked tests